### PR TITLE
Correct higher order co-moment analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Classical asset allocation is the efficient frontier allocation. This is also kn
 
 ### Higher Moment Optimisation
 The core principle of optimisation with higher moments is identical to any other optimisation: given some utility function and constraints, find the weights of each of the portfolio entries such that the utility function is maximised. The only difference is that the utility function in this case would contain as arguments, higher moments. Furthermore, by adding coefficients to each moment, we are able to take into account investor risk aversion and preferences.
+This version of the package includes higher moment optimization based on higher co-moments, which makes much more statistical sense than the column-wise higher order moments in the original package. 
 
 ### Compared to Sharpe Ratio
 When doing backtests, higher moment optimisation works better than using Sharpe ratio to optimise allocations.

--- a/portfolioopt/utility_functions.py
+++ b/portfolioopt/utility_functions.py
@@ -36,8 +36,8 @@ def sharpe(weights, mean, cov, risk_free_rate=0.02):
     :return: negative Sharpe ratio
     :rtype: float
     """
-    mu = weights.dot(expected_returns)
-    sigma = np.sqrt(np.dot(weights, np.dot(cov_matrix, weights.T)))
+    mu = weights.dot(mean)
+    sigma = np.sqrt(np.dot(weights, np.dot(cov, weights.T)))
     return -(mu - risk_free_rate) / sigma
 
 
@@ -49,7 +49,7 @@ def volatility(weights, cov):
     :return: portfolio variance
     :rtype: float
     """
-    portfolio_volatility = np.dot(weights.T, np.dot(cov_matrix, weights))
+    portfolio_volatility = np.dot(weights.T, np.dot(cov, weights))
     return portfolio_volatility
 
 
@@ -71,6 +71,27 @@ def moment_utility(weights, mean, cov, skew, kurt, delta1, delta2, delta3, delta
               delta2 * (np.dot(np.dot(np.transpose(weights), cov), weights)) + \
               delta3 * (np.dot(np.dot(np.transpose(weights), skew), weights)) - \
               delta4 * (np.dot(np.dot(np.transpose(weights), kurt), weights))
+    return -utility
+
+
+def comoment_utility(weights, mean, cov, coskew, cokurt, delta1, delta2, delta3, delta4):
+    """
+    Calculates the utility using mean, covariance, coskewness and cokurtosis of data.
+    :param weights: portfolio weights
+    :param mean: mean of market invariants
+    :param cov: covariance matrix of market invariants
+    :param skew: coskewness matrix of market invariants
+    :param kurt: cokurtosis matrix of market invariants
+    :param delta1: relative weight in optimization for mean
+    :param delta2: relative weight in optimization for covariance
+    :param delta3: relative weight in optimization for skew
+    :param delta4: relative weight in optimization for kurtosis
+    :return: portfolio utility
+    """
+    utility = delta1 * (np.dot(np.transpose(weights), mean)) - \
+              delta2 * (np.dot(np.dot(np.transpose(weights), cov), weights)) + \
+              delta3 * (np.dot(np.dot(np.transpose(x0), coskew), np.kron(x0,x0)))[0,0] - \
+              delta4 * (np.dot(np.dot(np.transpose(x0), cokurt), np.kron(np.kron(x0,x0),x0)))[0,0]
     return -utility
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup
 
 setup(
-    name='PortfolioAnalytics',
-    version='0.0.1',
+    name='portfolioopt',
+    version='0.0.2',
     packages=['portfolioopt'],
     url='https://github.com/VivekPa/PortfolioAnalytics',
     license='MIT',
-    author='Vivek Palaniappan',
+    author='Vivek Palaniappan and Sven Serneels',
     author_email='vivekpalaniappan69@gmail.com',
-    description='Robust Portfolio Optimisation and Analytics',
+    description='Portfolio Optimisation and Analytics',
     install_requires = ["numpy", "pandas", "scikit-learn", "scipy"],
     python_requires = ">=3",
     project_urls = {

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Vivek Palaniappan and Sven Serneels',
     author_email='vivekpalaniappan69@gmail.com',
     description='Portfolio Optimisation and Analytics',
-    install_requires = ["numpy", "pandas", "scikit-learn", "scipy"],
+    install_requires = ["numpy", "pandas", "scikit-learn", "scipy","rpy2"],
     python_requires = ">=3",
     project_urls = {
     "Documentation": "https://portfolioanalytics.readthedocs.io/en/latest/",


### PR DESCRIPTION
Hi Vivek 

Thanks for your package OptimalPortfolio. It created a great base structure for convex portfolio optimization in Python. However, I have improved the higher order moment analytics. Just  like you insert a covarianvce matrix for the second moment and *not* a vector of column wise variances, you should also use a co-skewness matrix and a co-kurtosis matrix instead of vectors of column-wise skewnesses and kurtoses.
I have implemented this modification correctly. Now there is a comoment_utility that will optimize based on these matrices. 
Remark: presently, I've taken correct co-moment matrix estimation from the R package 'PerformanceAnalytics' through rpy2. A next step will be to implement these in native Python. 

Best regards
Sven
